### PR TITLE
Network Relay Activation Profiles in Jamf Security Cloud

### DIFF
--- a/endpoints/idp/resource_idp.go
+++ b/endpoints/idp/resource_idp.go
@@ -8,9 +8,8 @@ import (
 	"io/ioutil"
 	"net/http"
 
-	"jsctfprovider/internal/auth"
-
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"jsctfprovider/internal/auth"
 )
 
 // Define the schema for the Okta resource


### PR DESCRIPTION
Added support for creating Network Relay Activation Profiles in Jamf Security Cloud. 

Example resource block with all relevant services enabled:

```
resource "jsc_ap" "activation_profile" {
  name              = "Network Relay + Threat and Content Control"
  idptype           = "NetworkRelay"
  privateaccess     = true     <--- Required for Network Relay
  threatdefence     = true
  datapolicy        = true
}
```