### PR TITLE
fix: preserve request body for retries in MakeRequest

### DIFF
--- a/internal/auth/auth.go
+++ b/internal/auth/auth.go
@@ -7,6 +7,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"io"
 	"io/ioutil"
 	"log"
 	"net"
@@ -372,6 +373,22 @@ func MakeRequest(req *http.Request) (*http.Response, error) {
 
 	maxRetries := 2
 	retryDelay := 2 * time.Second
+
+	// Preserve the request body for retries (body is consumed after each attempt)
+	var bodyBytes []byte
+	if req.Body != nil {
+		var err error
+		bodyBytes, err = ioutil.ReadAll(req.Body)
+		if err != nil {
+			return nil, fmt.Errorf("failed to read request body: %w", err)
+		}
+		req.Body.Close()
+		req.Body = ioutil.NopCloser(bytes.NewReader(bodyBytes))
+		req.GetBody = func() (io.ReadCloser, error) {
+			return ioutil.NopCloser(bytes.NewReader(bodyBytes)), nil
+		}
+	}
+
 	log.Println("[INFO] Building the client")
 	log.Println("[INFO] incoming url is " + req.URL.Path)
 	req.URL.RawQuery += "customerId=" + holdCustomerid
@@ -394,6 +411,10 @@ func MakeRequest(req *http.Request) (*http.Response, error) {
 	var err error
 	for attempt := 1; attempt <= maxRetries; attempt++ {
 		log.Printf("[INFO] Attempt %d/%d...\n", attempt, maxRetries)
+		// Reset the request body for retries (body is consumed after first attempt)
+		if req.GetBody != nil {
+			req.Body, _ = req.GetBody()
+		}
 		req.AddCookie(&http.Cookie{Name: "SESSION", Value: sessionCookie, Path: "/", SameSite: http.SameSiteLaxMode, Secure: true, HttpOnly: true})
 		log.Println("session cookie within loop is " + sessionCookie)
 		req.AddCookie(&http.Cookie{Name: "XSRF-TOKEN", Value: xsrfToken})


### PR DESCRIPTION
## Summary

- Fixes Bug 1 from #82: POST/PUT retry requests were sending empty bodies, causing 502 Bad Gateway errors
- The request body reader is consumed after the first `client.Do(req)` call, so retries had no body to send
- Now preserves the body bytes at the start of `MakeRequest` and resets the reader before each retry attempt

## Changes

- Read and store the request body bytes when `MakeRequest` is called
- Set up `req.GetBody` to return a fresh reader from the preserved bytes
- Reset `req.Body` using `req.GetBody()` before each retry attempt

## Test plan

- [x] Manual testing with provider against API
- [x] Verify POST/PUT operations retry correctly after 4xx responses

Fixes #82 (Bug 1)

🤖 Generated with [Claude Code](https://claude.com/claude-code)