### PR TITLE
fix: prevent routingdnstype drift when routingtype is DIRECT

### DIFF
--- a/endpoints/ztna_app/resource_ztnaapp.go
+++ b/endpoints/ztna_app/resource_ztnaapp.go
@@ -318,7 +318,12 @@ func resourceZTNAAppRead(d *schema.ResourceData, m interface{}) error {
 	d.Set("assignmentgroups", response.Assignments.Inclusions.Groups)
 	d.Set("routingtype", response.Routing.Type)
 	d.Set("routingid", response.Routing.RouteId)
-	d.Set("routingdnstype", response.Routing.DnsIpResolutionType)
+	// Only set routingdnstype when routing is not DIRECT, since the API
+	// returns empty for DIRECT and we want to preserve the config/default
+	// value to avoid false drift detection
+	if response.Routing.Type != "DIRECT" {
+		d.Set("routingdnstype", response.Routing.DnsIpResolutionType)
+	}
 	d.Set("securityriskcontrolenabled", response.Security.RiskControls.Enabled)
 	d.Set("securityriskcontrolthreshold", response.Security.RiskControls.LevelThreshold)
 	d.Set("securityriskcontrolnotifications", response.Security.RiskControls.NotificationsEnabled)


### PR DESCRIPTION
## Summary

- Fixes persistent drift for `routingdnstype` when `routingtype = "DIRECT"`
- The API returns empty for `dnsIpResolutionType` on DIRECT routing, which conflicted with schema default
- Now preserves the configured value since the field is irrelevant for DIRECT mode

Fixes #107

## Test plan

- [ ] Build provider locally with `go build -o terraform-provider-jsctf`
- [ ] Create access policy with `routingtype = "DIRECT"`
- [ ] Run `terraform plan` again - should show no changes
- [ ] Verify policy works correctly in JSC portal