### PR TITLE
fix: update routes datasource to use correct API view parameter

### DIFF
--- a/endpoints/routes/datasource_routes.go
+++ b/endpoints/routes/datasource_routes.go
@@ -58,7 +58,7 @@ func DataSourceRoutes() *schema.Resource {
 
 // Define the read function for routes
 func dataSourceRoutesRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	req, err := http.NewRequest("GET", "https://radar.wandera.com/gate/traffic-routing-service/v2/vpn-routes?view=deployments_with_status", nil)
+	req, err := http.NewRequest("GET", "https://radar.wandera.com/gate/traffic-routing-service/v2/vpn-routes?view=deployments", nil)
 	if err != nil {
 		return diag.FromErr(fmt.Errorf("failed to create HTTP request: %v", err))
 	}


### PR DESCRIPTION
## Summary

- Changes `jsc_routes` datasource from `view=deployments_with_status` to `view=deployments`
- Fixes 400 Bad Request errors when querying VPN routes

Fixes #106

## Test plan

- [ ] Build provider locally with `go build -o terraform-provider-jsctf`
- [ ] Query route by name: `data "jsc_routes" "test" { name = "Nearest Data Center" }`
- [ ] Verify route ID and datacenter are returned correctly