### PR TITLE
fix: mark clientsecret as sensitive in jsc_uemc resource

### DIFF
--- a/endpoints/uemc/resource_uemc.go
+++ b/endpoints/uemc/resource_uemc.go
@@ -38,6 +38,7 @@ func ResourceUEMC() *schema.Resource {
 			"clientsecret": {
 				Type:        schema.TypeString,
 				Required:    true,
+				Sensitive:   true,
 				Description: "Client Secret of Jamf Pro API Integration.",
 			},
 			"clientid": {


### PR DESCRIPTION
## Summary

- Adds `Sensitive: true` to the `clientsecret` schema field in `jsc_uemc`
- Prevents the secret from being exposed in error messages, plan output, and CI/CD logs

Fixes #125

## Test plan

- [ ] Build provider locally with `go build -o terraform-provider-jsctf`
- [ ] Create a `jsc_uemc` resource that triggers an error (e.g., 409 Conflict)
- [ ] Verify `clientsecret` is redacted as `(sensitive value)` in error output
- [ ] Run `terraform plan` and verify secret is not shown in diff