### PR TITLE
chore: remove debug fmt.Println statements

### DIFF
--- a/endpoints/activationprofiles/resource_activationprofiles.go
+++ b/endpoints/activationprofiles/resource_activationprofiles.go
@@ -333,17 +333,7 @@ func makepayloadstruct(activationprofilename string, idpconnectionid string, pri
 		// Add more Licenced Amalgams as needed...
 	}
 
-	// Marshal the struct into JSON
-	jsonData, err := json.MarshalIndent(data, "", "    ")
-	if err != nil {
-		fmt.Println("Error marshaling JSON:", err)
-		//return
-	}
-
-	// Print the JSON data
-	fmt.Println(string(jsonData))
 	return data
-
 }
 
 func makepayloadstructnoidp(activationprofilename string, threatdefence bool, datapolicy bool) DataNoIdP {
@@ -408,17 +398,7 @@ func makepayloadstructnoidp(activationprofilename string, threatdefence bool, da
 		// Add more Licenced Amalgams as needed...
 	}
 
-	// Marshal the struct into JSON
-	jsonData, err := json.MarshalIndent(data, "", "    ")
-	if err != nil {
-		fmt.Println("Error marshaling JSON:", err)
-		//return
-	}
-
-	// Print the JSON data
-	fmt.Println(string(jsonData))
 	return data
-
 }
 
 func makepayloadstructNR(activationprofilename string) DataNR {
@@ -477,12 +457,6 @@ func makepayloadstructNR(activationprofilename string) DataNR {
 			RootCertificates:             "OPTIONAL",
 			DefaultLocationServices:      "DISABLED",
 		},
-	}
-
-	// Print for debugging
-	jsonData, err := json.MarshalIndent(data, "", "    ")
-	if err == nil {
-		fmt.Println(string(jsonData))
 	}
 
 	return data
@@ -641,10 +615,6 @@ func resourceAPCreate(d *schema.ResourceData, m interface{}) error {
 	if err != nil {
 		return fmt.Errorf("an error occurred: %s", "additional information4")
 	}
-
-	// Parse the response JSON if needed
-	// (this depends on the structure of the API response)
-	fmt.Println(string(body))
 
 	// Parse the response JSON
 	var response struct {

--- a/endpoints/blockpages/resource_blockpage.go
+++ b/endpoints/blockpages/resource_blockpage.go
@@ -5,7 +5,6 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
 	"net/http"
 	"sync"
 
@@ -114,16 +113,6 @@ func resourceBlockPageCreate(d *schema.ResourceData, m interface{}) error {
 		return fmt.Errorf("failed to create block page : %s", resp.Status+" "+string(payload))
 	}
 
-	// Read the response body
-	body, err := ioutil.ReadAll(resp.Body)
-	if err != nil {
-		return fmt.Errorf("an error occurred: %s", "additional information4")
-	}
-
-	// Parse the response JSON if needed
-	// (this depends on the structure of the API response)
-	fmt.Println(string(body))
-
 	// Set the resource ID... hint there's only 1 ID of UEMC!
 	d.SetId("1")
 
@@ -153,16 +142,6 @@ func resourceBlockPageRead(d *schema.ResourceData, m interface{}) error {
 	if resp.StatusCode != http.StatusOK {
 		return fmt.Errorf("failed to read BlockPage info: %s", resp.Status)
 	}
-
-	// Read the response body
-	body, err := ioutil.ReadAll(resp.Body)
-	if err != nil {
-		return err
-	}
-
-	// Parse the response JSON if needed
-	// (this depends on the structure of the API response)
-	fmt.Println(string(body))
 
 	return nil
 }
@@ -215,16 +194,6 @@ func resourceBlockPageCDelete(d *schema.ResourceData, m interface{}) error {
 	if resp.StatusCode != http.StatusOK && resp.StatusCode != 204 {
 		return fmt.Errorf("failed to reset block page : %s", resp.Status+" "+string(payload))
 	}
-
-	// Read the response body
-	body, err := ioutil.ReadAll(resp.Body)
-	if err != nil {
-		return err
-	}
-
-	// Parse the response JSON if needed
-	// (this depends on the structure of the API response)
-	fmt.Println(string(body))
 
 	// Clear the resource ID
 	d.SetId("")

--- a/endpoints/categories/datasource_categories.go
+++ b/endpoints/categories/datasource_categories.go
@@ -74,9 +74,6 @@ func dataSourceCategoriesRead(ctx context.Context, d *schema.ResourceData, meta 
 		return diag.FromErr(fmt.Errorf("error making parsing body response"))
 	}
 
-	// Parse the response JSON if needed
-	// (this depends on the structure of the API response)
-	fmt.Println(string(body))
 	// Parse the response JSON
 
 	var response []Categories

--- a/endpoints/groups/datasource_groups.go
+++ b/endpoints/groups/datasource_groups.go
@@ -74,9 +74,6 @@ func dataSourceGroupsRead(ctx context.Context, d *schema.ResourceData, meta inte
 		return diag.FromErr(fmt.Errorf("error making parsing body response"))
 	}
 
-	// Parse the response JSON if needed
-	// (this depends on the structure of the API response)
-	fmt.Println(string(body))
 	// Parse the response JSON
 
 	var response []Groups

--- a/endpoints/hostnamemapping/datasource_hostnamemapping.go
+++ b/endpoints/hostnamemapping/datasource_hostnamemapping.go
@@ -181,19 +181,12 @@ func dataSourceMappingsRead(ctx context.Context, d *schema.ResourceData, meta in
 		return diag.FromErr(fmt.Errorf("error making parsing body response"))
 	}
 
-	// Parse the response JSON if needed
-	// (this depends on the structure of the API response)
-	fmt.Println(string(body))
 	// Parse the response JSON
-
 	var response Mappings
 	err = json.Unmarshal(body, &response)
 	if err != nil {
 		return diag.FromErr(err)
 	}
-
-	// Print the parsed struct
-	fmt.Printf("Parsed struct: %+v\n", response)
 
 	// Find id from the first instance where name contains "the provided name"
 

--- a/endpoints/hostnamemapping/resource_hostnamemapping.go
+++ b/endpoints/hostnamemapping/resource_hostnamemapping.go
@@ -90,19 +90,12 @@ func getAllHostnameMappings() (*Mappings, error) {
 		return nil, (fmt.Errorf("error making parsing body response"))
 	}
 
-	// Parse the response JSON if needed
-	// (this depends on the structure of the API response)
-	fmt.Println(string(body))
 	// Parse the response JSON
-
 	var response Mappings
 	err = json.Unmarshal(body, &response)
 	if err != nil {
 		return nil, (err)
 	}
-
-	// Print the parsed struct
-	fmt.Printf("Parsed struct: %+v\n", response)
 
 	return &response, nil
 }
@@ -126,19 +119,17 @@ func resourceHostnameMappingCreate(d *schema.ResourceData, m interface{}) error 
 
 	var aList []string
 	for _, item := range aSet.List() {
-		// Convert each item to a string
 		aList = append(aList, item.(string))
 	}
-	fmt.Println("A List:", aList)
+
 	// Convert schema.TypeSet to []string
 	aaaaSet := d.Get("aaaa").(*schema.Set)
 
 	var aaaaList []string
 	for _, item := range aaaaSet.List() {
-		// Convert each item to a string
 		aaaaList = append(aaaaList, item.(string))
 	}
-	fmt.Println("AAAA List:", aaaaList)
+
 	// Create a new Mapping to append
 	newMapping := Mapping{
 		Hostname:  d.Get("hostname").(string),
@@ -148,15 +139,13 @@ func resourceHostnameMappingCreate(d *schema.ResourceData, m interface{}) error 
 		AAAA:      aaaaList,
 	}
 	response.Mapping = append(response.Mapping, newMapping)
-	// Print the parsed struct
-	fmt.Printf("New Parsed struct: %+v\n", response)
 
 	payload, err := json.Marshal(response)
 	if err != nil {
 		return err
 	}
-	fmt.Println("JSON Payload:", string(payload))
-	// Make a PUT request to update all ammpings
+
+	// Make a PUT request to update all mappings
 	req, err := http.NewRequest("PUT", ("https://radar.wandera.com/gate/dns-zone-management-service/v1/custom-hostname-mappings"), bytes.NewBuffer(payload))
 	if err != nil {
 		return err
@@ -171,16 +160,6 @@ func resourceHostnameMappingCreate(d *schema.ResourceData, m interface{}) error 
 	if resp.StatusCode != http.StatusOK && resp.StatusCode != 201 {
 		return fmt.Errorf("failed to create hostname mapping: %s", resp.Status+" ")
 	}
-
-	// Read the response body
-	body, err := ioutil.ReadAll(resp.Body)
-	if err != nil {
-		return err
-	}
-
-	// Parse the response JSON if needed
-	// (this depends on the structure of the API response)
-	fmt.Println(string(body))
 
 	d.SetId(d.Get("hostname").(string))
 	return nil
@@ -237,14 +216,13 @@ func resourceHostnameMappingDelete(d *schema.ResourceData, m interface{}) error 
 		}
 	}
 	response.Mapping = filteredMappings
-	fmt.Printf("New Parsed struct: %+v\n", response)
 
 	payload, err := json.Marshal(response)
 	if err != nil {
 		return err
 	}
-	fmt.Println("JSON Payload:", string(payload))
-	// Make a PUT request to update all ammpings
+
+	// Make a PUT request to update all mappings
 	req, err := http.NewRequest("PUT", ("https://radar.wandera.com/gate/dns-zone-management-service/v1/custom-hostname-mappings"), bytes.NewBuffer(payload))
 	if err != nil {
 		return err
@@ -260,15 +238,6 @@ func resourceHostnameMappingDelete(d *schema.ResourceData, m interface{}) error 
 		return fmt.Errorf("failed to delete hostname mapping: %s", resp.Status+" ")
 	}
 
-	// Read the response body
-	body, err := ioutil.ReadAll(resp.Body)
-	if err != nil {
-		return err
-	}
-
-	// Parse the response JSON if needed
-	// (this depends on the structure of the API response)
-	fmt.Println(string(body))
 	// Clear the resource ID
 	d.SetId("")
 

--- a/endpoints/idp/resource_idp.go
+++ b/endpoints/idp/resource_idp.go
@@ -80,10 +80,6 @@ func resourceOktaIdpCreate(d *schema.ResourceData, m interface{}) error {
 		return err
 	}
 
-	// Parse the response JSON if needed
-	// (this depends on the structure of the API response)
-	fmt.Println(string(body))
-
 	// Parse the response JSON
 	var response struct {
 		ID string `json:"id"`
@@ -123,16 +119,6 @@ func resourceOktaIdpRead(d *schema.ResourceData, m interface{}) error {
 	if resp.StatusCode != http.StatusOK {
 		return fmt.Errorf("failed to read OKTA IDP info: %s", resp.Status)
 	}
-
-	// Read the response body
-	body, err := ioutil.ReadAll(resp.Body)
-	if err != nil {
-		return err
-	}
-
-	// Parse the response JSON if needed
-	// (this depends on the structure of the API response)
-	fmt.Println(string(body))
 
 	return nil
 }

--- a/endpoints/pag_apptemplates/datasource_pagapptemplates.go
+++ b/endpoints/pag_apptemplates/datasource_pagapptemplates.go
@@ -73,9 +73,6 @@ func dataSourcePAGAppTemplatesRead(ctx context.Context, d *schema.ResourceData, 
 		return diag.FromErr(fmt.Errorf("error making parsing body response"))
 	}
 
-	// Parse the response JSON if needed
-	// (this depends on the structure of the API response)
-	fmt.Println(string(body))
 	// Parse the response JSON
 
 	var response []ResponseItemAppTemplates

--- a/endpoints/pag_vpnroutes/datasource_pagvpnroutes.go
+++ b/endpoints/pag_vpnroutes/datasource_pagvpnroutes.go
@@ -73,9 +73,6 @@ func dataSourcePAGVPNRoutesRead(ctx context.Context, d *schema.ResourceData, met
 		return diag.FromErr(fmt.Errorf("error making parsing body response"))
 	}
 
-	// Parse the response JSON if needed
-	// (this depends on the structure of the API response)
-	fmt.Println(string(body))
 	// Parse the response JSON
 
 	var response []ResponseItem

--- a/endpoints/pag_ztna_app/datasource_pagztnaapp.go
+++ b/endpoints/pag_ztna_app/datasource_pagztnaapp.go
@@ -200,9 +200,6 @@ func dataSourcePAGZTNAAppRead(ctx context.Context, d *schema.ResourceData, meta 
 		return diag.FromErr(fmt.Errorf("error making parsing body response"))
 	}
 
-	// Parse the response JSON if needed
-	// (this depends on the structure of the API response)
-	fmt.Println(string(body))
 	// Parse the response JSON
 
 	var response []ResponseItemZTNAApps

--- a/endpoints/pag_ztna_app/resource_pagztnaapp.go
+++ b/endpoints/pag_ztna_app/resource_pagztnaapp.go
@@ -253,10 +253,6 @@ func resourcePAGZTNAAppCreate(d *schema.ResourceData, m interface{}) error {
 		return err
 	}
 
-	// Parse the response JSON if needed
-	// (this depends on the structure of the API response)
-	fmt.Println(string(body))
-
 	// Parse the response JSON
 	var response struct {
 		ID string `json:"id"`
@@ -298,11 +294,7 @@ func resourcePAGZTNAAppRead(d *schema.ResourceData, m interface{}) error {
 		return (fmt.Errorf("error making parsing body response"))
 	}
 
-	// Parse the response JSON if needed
-	// (this depends on the structure of the API response)
-	fmt.Println(string(body))
 	// Parse the response JSON
-
 	var response ResponseItemZTNAApp
 	err = json.Unmarshal(body, &response)
 	if err != nil {

--- a/endpoints/uemc/resource_uemc.go
+++ b/endpoints/uemc/resource_uemc.go
@@ -6,6 +6,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io/ioutil"
+	"log"
 	"net/http"
 
 	"jsctfprovider/internal/auth"
@@ -98,10 +99,6 @@ func resourceUEMCCreate(d *schema.ResourceData, m interface{}) error {
 		return err
 	}
 
-	// Parse the response JSON if needed
-	// (this depends on the structure of the API response)
-	fmt.Println(string(body))
-
 	// Parse the response JSON
 	var response struct {
 		ID string `json:"id"`
@@ -147,21 +144,13 @@ func resourceUEMCRead(d *schema.ResourceData, m interface{}) error {
 		return err
 	}
 
-	// Parse the response JSON if needed
-	// (this depends on the structure of the API response)
-	fmt.Println(string(body))
-
 	// Parse the response JSON and extract the ID
 	var configsResp ConfigsResponse
 	if err := json.Unmarshal(body, &configsResp); err != nil {
 		return err
 	}
 
-	if len(configsResp.Configs) > 0 {
-		configID := configsResp.Configs[0].ID
-		fmt.Println("Extracted config ID:", configID)
-
-	} else {
+	if len(configsResp.Configs) == 0 {
 		return fmt.Errorf("no configs found in response")
 	}
 
@@ -194,9 +183,9 @@ func resourceUEMCDelete(d *schema.ResourceData, m interface{}) error {
 	}
 	defer resp.Body.Close()
 
-	// Check the response status code
+	// Check the response status code - continue anyway to clear state
 	if resp.StatusCode != http.StatusOK && resp.StatusCode != 204 {
-		fmt.Println("failed to delete UEMC but removing state regardless: %v %v %v", resp.Status, resp, req)
+		log.Printf("[WARN] failed to delete UEMC (status %s), removing from state anyway", resp.Status)
 	}
 
 	// Clear the resource ID


### PR DESCRIPTION
## Summary
- Remove 34 debug `fmt.Println`/`Printf` statements across 12 resource and datasource files
- Clean up unused variables and imports that resulted from removing debug prints
- Convert one buggy `Println` with format verbs to proper `log.Printf` in uemc

## Files Changed
- endpoints/activationprofiles/resource_activationprofiles.go
- endpoints/blockpages/resource_blockpage.go
- endpoints/categories/datasource_categories.go
- endpoints/groups/datasource_groups.go
- endpoints/hostnamemapping/datasource_hostnamemapping.go
- endpoints/hostnamemapping/resource_hostnamemapping.go
- endpoints/idp/resource_idp.go
- endpoints/pag_apptemplates/datasource_pagapptemplates.go
- endpoints/pag_vpnroutes/datasource_pagvpnroutes.go
- endpoints/pag_ztna_app/datasource_pagztnaapp.go
- endpoints/pag_ztna_app/resource_pagztnaapp.go
- endpoints/uemc/resource_uemc.go

## Test plan
- [x] `go build -o terraform-provider-jsctf` succeeds
- [ ] Run terraform plan/apply with affected resources

Fixes #134