### PR TITLE
fix: resolve 500 error when deleting hostname mapping with AAAA records

### DIFF
--- a/endpoints/hostnamemapping/datasource_hostnamemapping.go
+++ b/endpoints/hostnamemapping/datasource_hostnamemapping.go
@@ -22,8 +22,8 @@ type Mapping struct {
 	Hostname  string   `json:"hostname"`
 	SecureDNS bool     `json:"secureDns"`
 	ZTNA      bool     `json:"ztna"`
-	A         []string `json:"A"`
-	AAAA      []string `json:"AAAA"`
+	A         []string `json:"A,omitempty"`
+	AAAA      []string `json:"AAAA,omitempty"`
 }
 
 type Mappings struct {


### PR DESCRIPTION
## Summary

- Adds `omitempty` to A and AAAA JSON tags in the `Mapping` struct
- When mappings without AAAA records were re-serialized, nil slices became JSON `null` values which the API rejected with 500 Internal Server Error
- Verified fix resolves the issue through manual testing

Fixes #116

## Test plan

- [x] Create hostname mapping with A record only
- [x] Create hostname mapping with A and AAAA records
- [x] Delete mapping with AAAA records — previously returned 500, now succeeds
- [x] Delete mapping with A only — still works as before