### PR TITLE
fix: mark jsc_admin username as immutable (ForceNew)

### DIFF
--- a/endpoints/admin/resource_admin.go
+++ b/endpoints/admin/resource_admin.go
@@ -125,7 +125,8 @@ func ResourceAdmin() *schema.Resource {
 			"username": {
 				Type:        schema.TypeString,
 				Required:    true,
-				Description: "Username (email address) for the admin account.",
+				ForceNew:    true,
+				Description: "Username (email address) for the admin account. Changing this forces a new resource.",
 			},
 			"roles": {
 				Type:        schema.TypeSet,


### PR DESCRIPTION
## Summary
- Adds `ForceNew: true` to the `username` field in `jsc_admin` resource
- The API silently ignores username updates via PUT, causing drift on every subsequent plan
- This fix forces a destroy/recreate when username changes, matching API behavior

Fixes #138

## Test plan
- [x] Create an admin with `username = "test@example.com"`
- [x] Change username in config and run `terraform plan`
- [x] Verify plan shows resource will be replaced (not updated in-place)