### PR TITLE
docs: add Hashicorp Registry link to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,11 @@
 Example TF for JSC
 
+## Installation
+
+For general usage, install from the [Hashicorp Registry](https://registry.terraform.io/providers/Jamf-Concepts/jsctfprovider/latest).
+
+The sections below are for local development.
+
 ## Building
 
 `go build -o terraform-provider-jsctf`


### PR DESCRIPTION
## Summary
- Adds Installation section at the top of README directing users to the Hashicorp Registry
- Clarifies that local build/dev instructions are for development purposes

## Test plan
- [x] Verify link is correct: https://registry.terraform.io/providers/Jamf-Concepts/jsctfprovider/latest

🤖 Generated with [Claude Code](https://claude.com/claude-code)